### PR TITLE
add downloaded image to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+wss-wu-dryville.jpg
+


### PR DESCRIPTION
Add downloaded Dryville image to .gitignore. Fixes #16 